### PR TITLE
Start script fixes

### DIFF
--- a/projects/buttons/fastener/scripts/start-button.sh
+++ b/projects/buttons/fastener/scripts/start-button.sh
@@ -121,19 +121,27 @@ fi
 ##
 
 if [ ! -d "/$SID" ]; then
+# #############################
+# # if demo not installed
+# #############################
+
+#create demo dir and cd into
 mkdir $SID
 cd $SID
 
-# TODO: conditional on DISTRO: fetch if specified, otherwise ignore
-#   - if no DISTRO to fetch, then this becomes a simple Fusion out of the box, box
-
+#copy demo data from bucket and unzip
 gsutil cp gs://buttons-streams/$DISTRO .
 tar xfz $DISTRO
 
 # check for existence (and executable-ness) of ./buttons-start.sh
 export FUSION_API_BASE; export FUSION_API_CREDENTIALS; export ADMIN_PASSWORD; export IP; ./buttons-start.sh
 
+# #############################
+# # end if demo not installed
+# #############################
 else
+
+#don't do anything
 echo "The demo is already installed"
 fi
 

--- a/projects/buttons/fastener/scripts/start-button.sh
+++ b/projects/buttons/fastener/scripts/start-button.sh
@@ -133,4 +133,8 @@ tar xfz $DISTRO
 # check for existence (and executable-ness) of ./buttons-start.sh
 export FUSION_API_BASE; export FUSION_API_CREDENTIALS; export ADMIN_PASSWORD; export IP; ./buttons-start.sh
 
+else
+echo "The demo is already installed"
+fi
+
 echo "$SID-$IID has been Galvanized"

--- a/projects/buttons/fastener/scripts/start-button.sh
+++ b/projects/buttons/fastener/scripts/start-button.sh
@@ -120,7 +120,7 @@ fi
 #    stream/app-specific handling
 ##
 
-
+if [ ! -d "/$SID" ]; then
 mkdir $SID
 cd $SID
 


### PR DESCRIPTION
Fixes #89 

Added conditional to check for "$SID" directory at root which is created on first spinup.

If directory does NOT exist: proceed as usual with exporting vars and executing buttons-start script

If directory does exist: echo "This demo is already installed" and skip running the buttons-start script. 

Tested on dev environment of labs, looks to be working.

Final thoughts: seems to be a good fix to avoid reimporting a demo and wiping changes. Can still possibly happen if the demo dir is wiped out or changed.  