### PR TITLE
Fix --set parameter to be parsed correctly by helm

### DIFF
--- a/projects/buttons/fastener/install_fusion5.sh
+++ b/projects/buttons/fastener/install_fusion5.sh
@@ -22,4 +22,4 @@ helm repo update
 
 echo -e "\nInstalling Fusion 5.0.2 Helm chart ${CHART_VERSION} into namespace ${NAMESPACE}"
 
-helm install --namespace "${NAMESPACE}" -n "${NAMESPACE}" "${lw_helm_repo}/fusion" --version "${CHART_VERSION}" --set api-gateway.ingress.enabled=true --set api-gateway.ingress.host="${NAMESPACE}.streams.lucidworks.com" --set  api-gateway.ingress.annotations["kubernetes.io/ingress.class"]="nginx"
+helm install --namespace "${NAMESPACE}" -n "${NAMESPACE}" "${lw_helm_repo}/fusion" --version "${CHART_VERSION}" --set api-gateway.ingress.enabled=true --set api-gateway.ingress.host="${NAMESPACE}.streams.lucidworks.com" --set  api-gateway.ingress.annotations."kubernetes\.io/ingress\.class"="nginx"


### PR DESCRIPTION
This PR:
  - Fixes the escaping of the `.` characters in the ingress annotations in the install command.